### PR TITLE
Ntp logging

### DIFF
--- a/main.c
+++ b/main.c
@@ -245,6 +245,8 @@ int main(int argc, char **argv) {
 	progname = argv[0];
 
 	init_logging(progname, 0, 0);
+	msyslog_include_timestamp = FALSE;
+	msyslog_term_pid = FALSE;
 	init_lib();
 	init_refclock();
 	init_recvbuff(4);

--- a/main.c
+++ b/main.c
@@ -245,6 +245,7 @@ int main(int argc, char **argv) {
 	progname = argv[0];
 
 	init_logging(progname, 0, 0);
+	closelog();
 	syslogit = FALSE;
 	msyslog_term = TRUE;
 	msyslog_include_timestamp = FALSE;

--- a/main.c
+++ b/main.c
@@ -245,6 +245,8 @@ int main(int argc, char **argv) {
 	progname = argv[0];
 
 	init_logging(progname, 0, 0);
+	syslogit = FALSE;
+	msyslog_term = TRUE;
 	msyslog_include_timestamp = FALSE;
 	msyslog_term_pid = FALSE;
 	init_lib();


### PR DESCRIPTION
The changes in this set make ntp logging play nice with ntp-refclock in that they disable some superfluous elements and excplitly disable and close syslog. This increases readability and avoids log/journal bloat when (temporarily) running ntp-refclock with debugging turned on to find out what the refclock it doing.